### PR TITLE
add support to @sveltejs/kit@^2.0.0 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"vitest": "^0.26.2"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.0.0"
+		"@sveltejs/kit": "^1.0.0 || ^2.0.0"
 	},
 	"type": "module",
 	"packageManager": "pnpm@7.20.0",


### PR DESCRIPTION
This should work with SvelteKit v2 and remove the warning

```
 WARN  Issues with peer dependencies found
.
└─┬ @prgm/sveltekit-progress-bar 1.0.0
  └── ✕ unmet peer @sveltejs/kit@^1.0.0: found 2.0.0
```